### PR TITLE
refactor: modernize plugin API usage and remove Google Charts

### DIFF
--- a/action.php
+++ b/action.php
@@ -6,9 +6,6 @@
  * @author		Michael Schuh <mike.schuh@gmx.at>
  */
 
-if(!defined('DOKU_INC')) die();
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once DOKU_PLUGIN.'action.php';
  
 class action_plugin_searchstats extends DokuWiki_Action_Plugin {
 
@@ -107,6 +104,7 @@ class action_plugin_searchstats extends DokuWiki_Action_Plugin {
 				}
 			}
 			fclose($writeF);
+			global $conf;
 			if($conf['fperm']) chmod($fn.'.tmp', $conf['fperm']);
 			io_rename($fn.'.tmp', $fn.'.idx');
 			return true;

--- a/admin.php
+++ b/admin.php
@@ -6,9 +6,7 @@
  * @author		Michael Schuh <mike.schuh@gmx.at>
  */
 
-if(!defined('DOKU_INC')) die();
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once DOKU_PLUGIN.'admin.php';
+use dokuwiki\Form\Form;
 
 class admin_plugin_searchstats extends DokuWiki_Admin_Plugin {
 
@@ -34,85 +32,36 @@ class admin_plugin_searchstats extends DokuWiki_Admin_Plugin {
 	
 	//Render html output for the plugin.
 	function html() {
+		$form = new Form();
+		
 		if(is_array($this->wordArray) && count($this->wordArray) > 0) {
-			ptln('<h1>'.$this->getLang('menu').'</h1>');
-			//print out bar chart
-			ptln('<br />');
-			$link = $this->_getBarChartTopKeywords(10);
-			ptln('<img src="'.$link.'" />');
-			//print out data table
-			ptln('<br /><br />');
-			ptln('<table class="inline">');
-			ptln('<tr class="row0">');
-			ptln('<th class="col0 leftalign">'.$this->getLang('th_word').'</th>');
-			ptln('<th class="col1">'.$this->getLang('th_count').'</th>');
-			ptln('</tr>');
+			// 添加標題
+			$form->addHTML('<h1>'.$this->getLang('menu').'</h1>');
+			
+			// 添加表格
+			$tableHTML = '<table class="inline">' . "\n";
+			$tableHTML .= '<tr class="row0">' . "\n";
+			$tableHTML .= '<th class="col0 leftalign">'.$this->getLang('th_word').'</th>' . "\n";
+			$tableHTML .= '<th class="col1">'.$this->getLang('th_count').'</th>' . "\n";
+			$tableHTML .= '</tr>' . "\n";
+			
 			foreach($this->wordArray as $word => $count) {
-				ptln('<tr>');
-				ptln('<td class="col0">'.$word.'</td>');
-				ptln('<td class="col1">'.$count.'</td>');
-				ptln('</tr>');
+				$tableHTML .= '<tr>' . "\n";
+				$tableHTML .= '<td class="col0">'.htmlspecialchars($word).'</td>' . "\n";
+				$tableHTML .= '<td class="col1">'.htmlspecialchars($count).'</td>' . "\n";
+				$tableHTML .= '</tr>' . "\n";
 			}
-			ptln('</table>');
+			$tableHTML .= '</table>' . "\n";
+			
+			$form->addHTML($tableHTML);
 		}
 		else {
-		  ptln('<h1>'.$this->getLang('nosearchwords').'</h1>');
+			$form->addHTML('<h1>'.$this->getLang('nosearchwords').'</h1>');
 		}
+		
+		echo $form->toHTML();
 	}
 
-	function _getBarChartTopKeywords($amount = 10) {
-		$countArray = count($this->wordArray);
-		$amount = ($countArray < $amount ? $countArray : $amount);
-		if(is_array($this->wordArray) && $amount > 0) {
-			$wordArray = array_slice($this->wordArray, 0, $amount);
-
-			$chxl = "&chxl=0:";
-			$chd = "&chd=t:";
-			$top = 0;
-			$i = 0;
-			foreach($wordArray as $word => $count) {
-				if($i == 0) {
-					if(function_exists('bcpow')) {
-						$top = bcpow(10, (int) strlen((string) $count));
-					}
-					else {
-						$strLen = (int) strlen((string) $count);
-						$top = 1;
-						while($strLen-- >= 1) {
-							$top = $top * 10;
-						}
-					}
-				}
-				$i++;
-				$chxl .= "|".$word;
-				$percentage = $count/$top*100;
-				$chd .= ($percentage).($i < $amount ? "," : "");
-			}
-			//$top = $top + (10-($top%10));
-			//set chart type to bar chart
-			$paramString = "?cht=bvg";
-			//set x and y axis visible
-			$paramString .= "&chxt=x,y";
-			//set min and max for y axis
-			$paramString .= "&chxr=1,0,".$top;
-			//set width and height for chart
-			$paramString .= "&chs=750x300";
-			//set color for bars
-			$paramString .= "&chco=A2C180";
-			//set chart title
-			$paramString .= "&chtt=".implode("+", explode(" ", $this->getLang('top10k')));
-			//set automatic bar width
-			$paramString .= "&chbh=a";
-			//chxl for custom axis labels
-			$paramString .= $chxl;
-			//chd for bar heights
-			$paramString .= $chd;
-
-			$link = "http://chart.apis.google.com/chart".$paramString;
-			return $link;
-		}
-		return false;
-	}
 
 	var $wordArray = array();
 

--- a/helper.php
+++ b/helper.php
@@ -5,7 +5,6 @@
  * @license		GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author		Michael Schuh <mike.schuh@gmx.at>
  */
-if (!defined('DOKU_INC')) die();
 
 class helper_plugin_searchstats extends DokuWiki_Plugin {
 
@@ -41,6 +40,9 @@ class helper_plugin_searchstats extends DokuWiki_Plugin {
 	function getSearchWordArray($amount = false) {
 		$wordArray = array();
 		$dir = $this->_getSaveFolder();
+		if (!is_dir($dir)) {
+			return $wordArray; // 回傳空陣列如果目錄不存在
+		}
 		if ($dh = opendir($dir)) {
 			while (($file = readdir($dh)) !== false) {
 				if(is_file($dir.'/'.$file) && strstr($file, 'idx')) {


### PR DESCRIPTION
- Migrate from ptln() to dokuwiki\Form\Form API
- Remove Google Charts bar chart functionality
- Fix PHP variable scope and initialization issues
- Add HTML escaping and improved error handling
- Clean up deprecated code and includes
- [fix: prevent CJK word segmentation in search statistics](https://github.com/Imhodad/dokuwiki-plugin-searchstats/commit/c543da1c839e387297d7349921fa6dc7a68a3bb7)